### PR TITLE
make undercloud_containers into an ansible role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+eggs/
+.eggs/
+*.egg-info/
+*.egg

--- a/doit.sh
+++ b/doit.sh
@@ -161,7 +161,7 @@ parameter_defaults:
   NeutronServicePlugins: ""
 EOF_CAT
 
-LOCAL_IP=${LOCAL_IP:-`ip -4 route get 8.8.8.8 | awk {'print $7'} | tr -d '\n'`}
+LOCAL_IP=${LOCAL_IP:-`/usr/sbin/ip -4 route get 8.8.8.8 | awk {'print $7'} | tr -d '\n'`}
 
 # run this to cleanup containers and volumes between iterations
 cat > $HOME/cleanup.sh <<-EOF_CAT

--- a/playbooks/undercloud_containers.yml
+++ b/playbooks/undercloud_containers.yml
@@ -1,0 +1,61 @@
+# This is the playbook used by the `quickstart.sh` script.
+
+# Add the virthost to the in-memory inventory. The inventory is not
+# written out to disk unless you call the `tripleo-inventory` role.
+- name: Add the virthost to the inventory
+  hosts: localhost
+  tasks:
+    - name: Add virthost
+      add_host:
+        name: "{{virthost}}"
+        groups: "virthost"
+        ansible_fqdn: "{{ virthost }}"
+        ansible_user: "root"
+        ansible_host: "{{ virthost }}"
+  tags:
+    - provision
+
+- include: teardown-provision.yml
+
+# The `provision.yml` playbook is responsible for
+# creating an inventory entry for our `virthost` and for creating an
+# unprivileged user on that host for use by our virtual environment.
+- include: provision.yml
+
+# These teardown tasks only make sense after running provision.yml,
+# because they assume they are connecting as the `stack` user rather
+# than `root`.
+- include: teardown-nodes.yml
+- include: teardown-environment.yml
+
+# The `environment/setup` role performs any tasks that require `root`
+# access on the target host.
+- name: Install libvirt packages and configure networks
+  hosts: virthost
+  gather_facts: yes
+  tags:
+    - environment
+  roles:
+    - environment/setup
+
+# The `libvirt/setup` role creates the undercloud and overcloud
+# virtual machines.
+- name:  Setup undercloud and overcloud vms
+  hosts: virthost
+  gather_facts: yes
+  roles:
+    - libvirt/setup
+
+
+- name: Add the undercloud node to the generated inventory
+  hosts: localhost
+  gather_facts: yes
+  roles:
+    - tripleo-inventory
+
+# Deploy the undercloud with containers
+- name:  Deploy the undercloud with containers
+  hosts: undercloud
+  gather_facts: yes
+  roles:
+    - undercloud-containers

--- a/roles/undercloud-containers/defaults/main.yml
+++ b/roles/undercloud-containers/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+undercloud_post_install_log: "{{ working_dir }}/undercloud_post_install.log"
+undercloud_setup_install_log: "{{ working_dir }}/doit.log"
+undercloud_install_log: "{{ working_dir }}/run.log"

--- a/roles/undercloud-containers/files/README.md
+++ b/roles/undercloud-containers/files/README.md
@@ -1,0 +1,1 @@
+Files are copied into this dir from the base of the repo

--- a/roles/undercloud-containers/meta/main.yml
+++ b/roles/undercloud-containers/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - common
+  - extras-common

--- a/roles/undercloud-containers/tasks/create-scripts.yml
+++ b/roles/undercloud-containers/tasks/create-scripts.yml
@@ -1,0 +1,13 @@
+# Creat the scripts that will be used to deploy the undercloud
+# environment.
+- name: Create undercloud install script
+  synchronize:
+    src: files/{{ item }}
+    dest: "{{ working_dir }}/"
+    use_ssh_args: true
+  with_items:
+    - cleanup.sh
+    - doit.sh
+    - dprince.sh
+    - post_install.sh
+

--- a/roles/undercloud-containers/tasks/install-undercloud.yml
+++ b/roles/undercloud-containers/tasks/install-undercloud.yml
@@ -1,0 +1,22 @@
+- name: Prepare directory with extra logs
+  file: dest=/var/log/extra state=directory
+  become: true
+
+# No need to install dstat package here because it is part of the images
+- name: Run dstat for collecting metrics during 2 hours
+  command: >
+    dstat -tcmndrylpg --nocolor --output /var/log/extra/dstat-csv.log 1 7200 \
+    >/dev/null
+  async: 7200
+  poll: 0
+  become: true
+
+- name: Create the undercloud install script
+  shell: |
+    {{ working_dir }}/doit.sh > \
+    {{ undercloud_setup_install_log }} 2>&1
+
+- name: Install the undercloud
+  shell: |
+    {{ working_dir }}/run.sh > \
+    {{ undercloud_install_log }} 2>&1

--- a/roles/undercloud-containers/tasks/main.yml
+++ b/roles/undercloud-containers/tasks/main.yml
@@ -1,0 +1,12 @@
+- include: create-scripts.yml
+  tags:
+    - undercloud-scripts
+
+- include: install-undercloud.yml
+  tags:
+    - undercloud-install
+
+- include: post-install.yml
+  tags:
+    - undercloud-post-install
+

--- a/roles/undercloud-containers/tasks/post-install.yml
+++ b/roles/undercloud-containers/tasks/post-install.yml
@@ -1,0 +1,21 @@
+# Extract the undercloud admin password from
+# `undercloud-passwords.conf`.
+- name: Get undercloud admin password
+  command: >
+    awk -F= '$1 == "undercloud_admin_password" {print $2}'
+    {{ working_dir }}/undercloud-passwords.conf
+  register: undercloud_admin_password
+  changed_when: false
+
+- name: Copy stackrc to ansible host
+  tags:
+    - undercloud-post-install
+  fetch:
+    flat: true
+    src: stackrc
+    dest: "{{ local_working_dir }}/stackrc"
+
+- name: Execute post install for the undercloud
+  shell: |
+    {{ working_dir }}/post-install.sh > \
+    {{ undercloud_post_install.log }} 2>&1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,46 @@
+[metadata]
+name = undercloud_containers 
+summary = development role used for tripleo and containers
+description-file =
+    README.md
+author = Dan Prince
+author-email = dprince@redhat.com
+author = Wes Hayutin
+author-email = weshayutin@redhat.com
+home-page = http://docs.openstack.org/developer/tripleo-quickstart/
+classifier =
+  License :: OSI Approved :: Apache Software License
+  Development Status :: 4 - Beta
+  Intended Audience :: Developers
+  Intended Audience :: System Administrators
+  Intended Audience :: Information Technology
+  Topic :: Utilities
+
+[build_sphinx]
+all_files = 1
+build-dir = doc/build
+source-dir = doc/source
+
+[global]
+setup-hooks =
+    pbr.hooks.setup_hook
+
+[files]
+data_files =
+    config = config/*
+    playbooks = playbooks/*
+    usr/local/share/ansible/roles = roles/*
+    usr/local/share/ansible/roles/undercloud-containers/files = build_kolla.sh
+    usr/local/share/ansible/roles/undercloud-containers/files = cleanup.sh
+    usr/local/share/ansible/roles/undercloud-containers/files = doit.sh
+    usr/local/share/ansible/roles/undercloud-containers/files = dprince.sh
+    usr/local/share/ansible/roles/undercloud-containers/files = post_install.sh
+    usr/local/share/ansible/roles/undercloud-containers/files = undercloud-vm.sh
+    usr/local/share/ansible/roles/undercloud-containers/files = vm_doit.sh
+
+[wheel]
+universal = 1
+
+[pbr]
+skip_authors = True
+skip_changelog = True

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+#   Copyright Red Hat, Inc. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+
+import setuptools
+
+setuptools.setup(
+    setup_requires=['pbr'],
+    pbr=True)


### PR DESCRIPTION
Make the undercloud_containers git repo into an ansible role
that can be called by tripleo-quickstart with out intrupting the
workflow that developers are currecntly using.

* create the ansible role stucture
* adjust the setup.cfg to place scripts into the right directories
* fully qualify the ip command