### PR TITLE
Copy undercloud.conf to home directory

### DIFF
--- a/doit.sh
+++ b/doit.sh
@@ -198,6 +198,9 @@ time openstack undercloud install --experimental \\
 EOF_CAT
 chmod 755 $HOME/run.sh
 
+if [ ! -f $HOME/undercloud.conf ]; then
+    cp $(dirname "${BASH_SOURCE[0]}")/undercloud.conf $HOME/undercloud.conf
+fi
 sed -i "s/@@LOCAL_IP@@/$LOCAL_IP/" $HOME/undercloud.conf
 sed -i "s#@@CONTAINERS_FILE@@#$HOME/containers.yaml#" $HOME/undercloud.conf
 


### PR DESCRIPTION
doit.sh was trying to do some replacements on undercloud.conf,
however, that file was on the repo root, not on the home directory.

This copies the undercloud.conf from the repo to the home directory
and makes the replacement work.