### PR TITLE
Use containers.yaml instead of containers-rdo.yaml in doit.sh

### DIFF
--- a/doit.sh
+++ b/doit.sh
@@ -240,8 +240,8 @@ openstack overcloud container image prepare --namespace=172.19.0.2:8787/tripleou
 openstack overcloud container image prepare \
   --tag passed-ci \
   --namespace docker.io/tripleopike \
-  --output-env-file=$HOME/containers-rdo.yaml \
-  --template-file $HOME/containers-rdo.yaml
+  --output-env-file=$HOME/containers.yaml \
+  --template-file $HOME/containers.yaml
   -r tripleo-heat-templates/roles_data_undercloud.yaml \
   -e tripleo-heat-templates/environments/docker.yaml \
   -e tripleo-heat-templates/environments/services-docker/mistral.yaml \

--- a/doit.sh
+++ b/doit.sh
@@ -241,7 +241,7 @@ openstack overcloud container image prepare \
   --tag passed-ci \
   --namespace docker.io/tripleopike \
   --output-env-file=$HOME/containers.yaml \
-  --template-file $HOME/containers.yaml
+  --template-file $HOME/containers.yaml \
   -r tripleo-heat-templates/roles_data_undercloud.yaml \
   -e tripleo-heat-templates/environments/docker.yaml \
   -e tripleo-heat-templates/environments/services-docker/mistral.yaml \


### PR DESCRIPTION
At the point where it's called, containers-rdo.yaml doesn't exist. This
results in an error. containers.yaml is generated in the call above.